### PR TITLE
#29 アプリ名を変更する

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
          FlutterApplication and put your custom class here. -->
     <application
         android:name="io.flutter.app.FlutterApplication"
-        android:label="ohayo_post_app"
+        android:label="おはようポスト"
         android:icon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>ohayo_post_app</string>
+	<string>おはようポスト</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
## 関連のIssue
- #29（ ※ このプルリクがマージされたら、自動でクローズされます -> コマンド：close #29 ）

## 修正箇所の概要
- アプリ名を「ohayo_post_app」から「おはようポスト」に変更しました

## ビルド後の画面イメージ
|アプリアイコン下のアプリ名|アプリ選択画面のアプリ名|
|-|-|
|<image src="https://user-images.githubusercontent.com/55462291/106357087-47997800-6347-11eb-9c9b-e3443eef5c80.png" width="250">|<image src="https://user-images.githubusercontent.com/55462291/106357101-5b44de80-6347-11eb-90e8-f796e975532a.png" width="250">|

## 実装者が行ったテスト
- [x] アプリアイコン下のアプリ名が「おはようポスト」に変わっている事を確認しました
- [x] アプリ選択画面のアプリ名が「おはようポスト」に変わっている事を確認しました
