### PR TITLE
#35 syncfusion_flutter_chartsを導入して起床時間分析を簡易実装する

### DIFF
--- a/lib/data_service/post_data_service.dart
+++ b/lib/data_service/post_data_service.dart
@@ -9,7 +9,7 @@ class PostDataService {
     final _postMap = {
       'contributorId': post.contributorId,
       'postId': postId,
-      'target': post.target,
+      'target': post.feeling,
       'createdAt': Timestamp.now(),
       'updatedAt': Timestamp.now(),
     };

--- a/lib/data_service/post_data_service.dart
+++ b/lib/data_service/post_data_service.dart
@@ -9,7 +9,7 @@ class PostDataService {
     final _postMap = {
       'contributorId': post.contributorId,
       'postId': postId,
-      'target': post.feeling,
+      'feeling': post.feeling,
       'createdAt': Timestamp.now(),
       'updatedAt': Timestamp.now(),
     };

--- a/lib/data_service/post_data_service.dart
+++ b/lib/data_service/post_data_service.dart
@@ -29,7 +29,7 @@ class PostDataService {
           return Post.fromDocumentSnapshot(doc);
         }).toList()
           // orderを使うとsnapshotsが0件になるためsort()で降順(新しい投稿順)にした
-          ..sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
       },
     );
   }

--- a/lib/model/post.dart
+++ b/lib/model/post.dart
@@ -9,6 +9,7 @@ class Post {
     this.sleepingRecords,
     this.reflection,
     this.feeling,
+    this.target,
     this.createdAt,
     this.updatedAt,
   });
@@ -31,6 +32,9 @@ class Post {
   /// 今朝の気持ち
   final String feeling;
 
+  /// 今日の目標
+  final String target;
+
   /// 登録日
   final DateTime createdAt;
 
@@ -45,6 +49,7 @@ class Post {
     Map<String, int> sleepingRecords,
     String reflection,
     String feeling,
+    String target,
     DateTime createdAt,
     DateTime updatedAt,
   }) {
@@ -55,6 +60,7 @@ class Post {
       sleepingRecords: sleepingRecords ?? this.sleepingRecords,
       reflection: reflection ?? this.reflection,
       feeling: feeling ?? this.feeling,
+      target: target ?? this.target,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );
@@ -69,6 +75,7 @@ class Post {
       sleepingRecords: null,
       reflection: '',
       feeling: '',
+      target: '',
       createdAt: null,
       updatedAt: null,
     );
@@ -83,6 +90,7 @@ class Post {
       sleepingRecords: data['sleepingRecords'] ?? null,
       reflection: data['reflection'] ?? '',
       feeling: data['feeling'] ?? '',
+      target: data['target'] ?? '',
       createdAt: data['createdAt'] != null
           ? (data['createdAt'] as Timestamp).toDate()
           : null,

--- a/lib/model/post.dart
+++ b/lib/model/post.dart
@@ -8,7 +8,7 @@ class Post {
     this.postId,
     this.sleepingRecords,
     this.reflection,
-    this.target,
+    this.feeling,
     this.createdAt,
     this.updatedAt,
   });
@@ -28,8 +28,8 @@ class Post {
   /// 昨日の振り返り
   final String reflection;
 
-  /// 今日の目標
-  final String target;
+  /// 今朝の気持ち
+  final String feeling;
 
   /// 登録日
   final DateTime createdAt;
@@ -44,7 +44,7 @@ class Post {
     String postId,
     Map<String, int> sleepingRecords,
     String reflection,
-    String target,
+    String feeling,
     DateTime createdAt,
     DateTime updatedAt,
   }) {
@@ -54,7 +54,7 @@ class Post {
       postId: postId ?? this.postId,
       sleepingRecords: sleepingRecords ?? this.sleepingRecords,
       reflection: reflection ?? this.reflection,
-      target: target ?? this.target,
+      feeling: feeling ?? this.feeling,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
     );
@@ -68,7 +68,7 @@ class Post {
       postId: '',
       sleepingRecords: null,
       reflection: '',
-      target: '',
+      feeling: '',
       createdAt: null,
       updatedAt: null,
     );
@@ -82,7 +82,7 @@ class Post {
       postId: data['postId'] ?? '',
       sleepingRecords: data['sleepingRecords'] ?? null,
       reflection: data['reflection'] ?? '',
-      target: data['target'] ?? '',
+      feeling: data['feeling'] ?? '',
       createdAt: data['createdAt'] != null
           ? (data['createdAt'] as Timestamp).toDate()
           : null,

--- a/lib/model/wake_up_time.dart
+++ b/lib/model/wake_up_time.dart
@@ -1,0 +1,5 @@
+class WakeUpTime {
+  WakeUpTime(this.label, this.time);
+  final String label;
+  final double time;
+}

--- a/lib/notifier/post_notifier.dart
+++ b/lib/notifier/post_notifier.dart
@@ -18,7 +18,7 @@ class PostNotifier with ChangeNotifier {
   Post get post => _post; // おはよう報告の下書き機能が実装する時に使用予定
 
   void setTarget(String target) {
-    _post = _post.copyWith(target: target);
+    _post = _post.copyWith(feeling: target);
     notifyListeners();
   }
 

--- a/lib/screen/analysis/analysis_screen.dart
+++ b/lib/screen/analysis/analysis_screen.dart
@@ -1,12 +1,48 @@
 import 'package:flutter/material.dart';
 import 'package:ohayo_post_app/widget/posting_floating_action_button.dart';
+import 'package:syncfusion_flutter_charts/charts.dart';
 
 class AnalysisScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final List<ChartData> chartData = [
+      ChartData('ねこ', 5),
+      ChartData('お父さん', 8),
+      ChartData('お母さん', 4),
+      ChartData('ぼく', 2)
+    ];
+
     return Scaffold(
       appBar: AppBar(title: Text('分析')),
       floatingActionButton: PostingFloatingActionButton(),
+      body: Center(
+        child: Container(
+          child: SfPyramidChart(
+            title: ChartTitle(text: '家庭内権力図'),
+            palette: <Color>[
+              Colors.orange[300],
+              Colors.orange[200],
+              Colors.orange[100],
+              Colors.orange[50]
+            ],
+            tooltipBehavior: TooltipBehavior(enable: true),
+            legend: Legend(isVisible: true),
+            series: PyramidSeries<ChartData, String>(
+              dataSource: chartData,
+              xValueMapper: (ChartData data, _) => data.x,
+              yValueMapper: (ChartData data, _) => data.y,
+              dataLabelSettings: DataLabelSettings(isVisible: true),
+            ),
+          ),
+        ),
+      ),
     );
   }
+}
+
+class ChartData {
+  ChartData(this.x, this.y, [this.color]);
+  final String x;
+  final double y;
+  final Color color;
 }

--- a/lib/screen/analysis/analysis_screen.dart
+++ b/lib/screen/analysis/analysis_screen.dart
@@ -1,48 +1,53 @@
 import 'package:flutter/material.dart';
+import 'package:ohayo_post_app/model/wake_up_time.dart';
+import 'package:ohayo_post_app/notifier/post_notifier.dart';
+import 'package:ohayo_post_app/utility/convert.dart';
 import 'package:ohayo_post_app/widget/posting_floating_action_button.dart';
+import 'package:provider/provider.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
 
 class AnalysisScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final List<ChartData> chartData = [
-      ChartData('ねこ', 5),
-      ChartData('お父さん', 8),
-      ChartData('お母さん', 4),
-      ChartData('ぼく', 2)
-    ];
+    final postNtf = Provider.of<PostNotifier>(context);
+    final posts = postNtf.posts
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    final wakeUpTimes = posts
+        .map((post) => WakeUpTime(Convert().getMonthDayWeekDay(post.createdAt),
+            Convert().getHourMinute(post.createdAt)))
+        .toList();
 
     return Scaffold(
       appBar: AppBar(title: Text('分析')),
       floatingActionButton: PostingFloatingActionButton(),
       body: Center(
-        child: Container(
-          child: SfPyramidChart(
-            title: ChartTitle(text: '家庭内権力図'),
-            palette: <Color>[
-              Colors.orange[300],
-              Colors.orange[200],
-              Colors.orange[100],
-              Colors.orange[50]
-            ],
-            tooltipBehavior: TooltipBehavior(enable: true),
-            legend: Legend(isVisible: true),
-            series: PyramidSeries<ChartData, String>(
-              dataSource: chartData,
-              xValueMapper: (ChartData data, _) => data.x,
-              yValueMapper: (ChartData data, _) => data.y,
-              dataLabelSettings: DataLabelSettings(isVisible: true),
+        child: Transform.translate(
+          offset: Offset(0, -60),
+          child: Container(
+            height: MediaQuery.of(context).size.height * 0.7,
+            width: MediaQuery.of(context).size.width * 0.9,
+            child: SfCartesianChart(
+              primaryXAxis: CategoryAxis(),
+              // Chart title
+              title: ChartTitle(text: '起床時間'),
+              // Enable legend
+              legend: Legend(isVisible: true),
+              // Enable tooltip
+              tooltipBehavior: TooltipBehavior(enable: true),
+              series: <LineSeries<WakeUpTime, String>>[
+                LineSeries<WakeUpTime, String>(
+                    dataSource: wakeUpTimes,
+                    xValueMapper: (WakeUpTime wakeUpTimes, _) =>
+                        wakeUpTimes.label.toString(),
+                    yValueMapper: (WakeUpTime wakeUpTimes, _) =>
+                        wakeUpTimes.time,
+                    // Enable data label
+                    dataLabelSettings: DataLabelSettings(isVisible: true))
+              ],
             ),
           ),
         ),
       ),
     );
   }
-}
-
-class ChartData {
-  ChartData(this.x, this.y, [this.color]);
-  final String x;
-  final double y;
-  final Color color;
 }

--- a/lib/screen/analysis/analysis_screen.dart
+++ b/lib/screen/analysis/analysis_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:ohayo_post_app/model/wake_up_time.dart';
+import 'package:ohayo_post_app/notifier/person_notifier.dart';
 import 'package:ohayo_post_app/notifier/post_notifier.dart';
 import 'package:ohayo_post_app/utility/convert.dart';
 import 'package:ohayo_post_app/widget/posting_floating_action_button.dart';
@@ -16,6 +17,7 @@ class AnalysisScreen extends StatelessWidget {
         .map((post) => WakeUpTime(Convert().getMonthDayWeekDay(post.createdAt),
             Convert().getHourMinute(post.createdAt)))
         .toList();
+    final personNtf = Provider.of<PersonNotifier>(context);
 
     return Scaffold(
       appBar: AppBar(title: Text('分析')),
@@ -29,7 +31,7 @@ class AnalysisScreen extends StatelessWidget {
             child: SfCartesianChart(
               primaryXAxis: CategoryAxis(),
               // Chart title
-              title: ChartTitle(text: '起床時間'),
+              title: ChartTitle(text: '${personNtf.person.nickName}さんの起床時間'),
               // Enable legend
               legend: Legend(isVisible: true),
               // Enable tooltip

--- a/lib/screen/analysis/analysis_screen.dart
+++ b/lib/screen/analysis/analysis_screen.dart
@@ -31,20 +31,21 @@ class AnalysisScreen extends StatelessWidget {
             child: SfCartesianChart(
               primaryXAxis: CategoryAxis(),
               // Chart title
-              title: ChartTitle(text: '${personNtf.person.nickName}さんの起床時間'),
+              title: ChartTitle(text: '${personNtf.person.nickName}さんの睡眠分析'),
               // Enable legend
               legend: Legend(isVisible: true),
               // Enable tooltip
               tooltipBehavior: TooltipBehavior(enable: true),
               series: <LineSeries<WakeUpTime, String>>[
                 LineSeries<WakeUpTime, String>(
-                    dataSource: wakeUpTimes,
-                    xValueMapper: (WakeUpTime wakeUpTimes, _) =>
-                        wakeUpTimes.label.toString(),
-                    yValueMapper: (WakeUpTime wakeUpTimes, _) =>
-                        wakeUpTimes.time,
-                    // Enable data label
-                    dataLabelSettings: DataLabelSettings(isVisible: true))
+                  name: '起床時間',
+                  dataSource: wakeUpTimes,
+                  xValueMapper: (WakeUpTime wakeUpTimes, _) =>
+                      wakeUpTimes.label.toString(),
+                  yValueMapper: (WakeUpTime wakeUpTimes, _) => wakeUpTimes.time,
+                  // Enable data label
+                  dataLabelSettings: DataLabelSettings(isVisible: true),
+                ),
               ],
             ),
           ),

--- a/lib/screen/analysis/analysis_screen.dart
+++ b/lib/screen/analysis/analysis_screen.dart
@@ -11,7 +11,7 @@ class AnalysisScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final postNtf = Provider.of<PostNotifier>(context);
     final posts = postNtf.posts
-      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      ..sort((a, b) => a.createdAt.compareTo(b.createdAt));
     final wakeUpTimes = posts
         .map((post) => WakeUpTime(Convert().getMonthDayWeekDay(post.createdAt),
             Convert().getHourMinute(post.createdAt)))

--- a/lib/screen/my_page/my_page_screen.dart
+++ b/lib/screen/my_page/my_page_screen.dart
@@ -11,6 +11,7 @@ class MyPageScreen extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(title: Text('マイページ')),
+      floatingActionButton: PostingFloatingActionButton(),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -21,7 +22,6 @@ class MyPageScreen extends StatelessWidget {
           ],
         ),
       ),
-      floatingActionButton: PostingFloatingActionButton(),
     );
   }
 }

--- a/lib/screen/time_line/time_line_screen.dart
+++ b/lib/screen/time_line/time_line_screen.dart
@@ -18,6 +18,7 @@ class TimeLineScreen extends StatelessWidget {
           if (snapshot.connectionState == ConnectionState.done) {
             return Scaffold(
               appBar: AppBar(title: Text('タイムライン')),
+              floatingActionButton: PostingFloatingActionButton(),
               body: Center(
                 child: postNtf.posts.isEmpty
                     ? Padding(
@@ -81,7 +82,6 @@ class TimeLineScreen extends StatelessWidget {
                         ),
                       ),
               ),
-              floatingActionButton: PostingFloatingActionButton(),
             );
           }
           // postsとcontributorDataの紐付け待ち

--- a/lib/screen/time_line/time_line_screen.dart
+++ b/lib/screen/time_line/time_line_screen.dart
@@ -73,7 +73,7 @@ class TimeLineScreen extends StatelessWidget {
                                     padding: const EdgeInsets.symmetric(
                                         horizontal: 8),
                                     child:
-                                        Text('${postNtf.posts[index].target}'),
+                                        Text('${postNtf.posts[index].feeling}'),
                                   ),
                                 ),
                               ],

--- a/lib/screen/time_line/time_line_screen.dart
+++ b/lib/screen/time_line/time_line_screen.dart
@@ -56,7 +56,7 @@ class TimeLineScreen extends StatelessWidget {
                                         Text(
                                             '${postNtf.posts[index].contributorData.nickName}'),
                                         Text(
-                                            '${Convert().getJapaneseDateFormat(postNtf.posts[index].createdAt)}'),
+                                            '${Convert().getYearMonthDayWeekDayHourMinute(postNtf.posts[index].createdAt)}'),
                                       ],
                                     ),
                                   ],

--- a/lib/utility/convert.dart
+++ b/lib/utility/convert.dart
@@ -2,10 +2,24 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart';
 
 class Convert {
-  String getJapaneseDateFormat(DateTime dateTime) {
+  String getYearMonthDayWeekDayHourMinute(DateTime dateTime) {
     initializeDateFormatting('ja');
     final yearMonthDayWeekDay = DateFormat.yMMMEd('ja').format(dateTime);
     final hourMinute = DateFormat.Hm('ja').format(dateTime);
     return yearMonthDayWeekDay + ' ' + hourMinute;
+  }
+
+  String getMonthDayWeekDay(DateTime dateTime) {
+    initializeDateFormatting('ja');
+    final monthDayWeekDay = DateFormat.MEd('ja').format(dateTime);
+    return monthDayWeekDay;
+  }
+
+  double getHourMinute(DateTime dateTime) {
+    final hour = DateFormat.H().format(dateTime);
+    final minute = DateFormat.m().format(dateTime);
+    final hourMinute =
+        double.parse(hour) + (double.parse(minute) / 60); //時間と分を小数に変換
+    return (hourMinute * 10).roundToDouble() / 10; //小数点第二位以下を四捨五入で切り上げ
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -322,6 +322,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0-nullsafety.1"
+  syncfusion_flutter_charts:
+    dependency: "direct main"
+    description:
+      name: syncfusion_flutter_charts
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "18.4.39"
+  syncfusion_flutter_core:
+    dependency: transitive
+    description:
+      name: syncfusion_flutter_core
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "18.4.39"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,16 +23,14 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  cupertino_icons: ^1.0.0
   firebase_core: ^0.7.0
   firebase_auth: ^0.20.0+1
   cloud_firestore: ^0.16.0
   provider: ^4.3.3
   intl: ^0.16.1
   dotted_border: ^1.0.7
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.0
+  syncfusion_flutter_charts: ^18.4.39
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 関連のIssue
- #35（ ※ このプルリクがマージされたら、自動でクローズされます -> コマンド：close #35 ）

## 修正箇所の概要
- `syncfusion_flutter_charts`を導入して起床時間分析を簡易実装しました

## ビルド後の画面イメージ
|タイムライン|分析|
|-|-|
|<image src="https://user-images.githubusercontent.com/55462291/106377636-c80cb700-63e1-11eb-88d5-1766d7124a46.png" width="250">|<image src="https://user-images.githubusercontent.com/55462291/106377664-e96da300-63e1-11eb-818e-c68b4a4b1be6.png" width="250">|

## 実装者が行ったテスト
- [x] タイムラインにポストしたおはよう報告の報告日を起床時間としてピックアップし、分析に折れ線グラフが表示されている事を確認しました
