### PR TITLE
#37 Android版のアプリを簡易リリースする

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -8,7 +8,8 @@ GeneratedPluginRegistrant.java
 
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/docs/deployment/android#reference-the-keystore-from-the-app
-key.properties
+/keystore.properties
+/app/release.jks
 
 # Firebase Setting
-**/google-services**.json
+/app/google-services*.json

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -64,9 +64,7 @@ android {
 
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.release
         }
     }
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,6 +26,8 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.google.gms.google-services'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def keystorePropertiesFile = rootProject.file("keystore.properties")
+
 android {
     compileSdkVersion 30
 
@@ -45,6 +47,19 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true
+    }
+
+    signingConfigs {
+        release {
+            if (keystorePropertiesFile.exists()) {
+                def keystoreProperties = new Properties()
+                keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+                keyAlias keystoreProperties['keyAlias']
+                keyPassword keystoreProperties['keyPassword']
+                storeFile file(keystoreProperties['storeFile'])
+                storePassword keystoreProperties['storePassword']
+            }
+        }
     }
 
     buildTypes {


### PR DESCRIPTION
## 関連のIssue
- #37（ ※ このプルリクがマージされたら、自動でクローズされます -> コマンド：close #37 ）

## 修正箇所の概要
- Android版のアプリを簡易リリースしました

## ビルド後の画面イメージ
- 画面変更はなし
- GooglePlayConsoleのリリース申請画面
<image src="https://user-images.githubusercontent.com/55462291/106407414-51be9200-647f-11eb-9053-6a7adb35d425.png" width="500">

## 実装者が行ったテスト
- [x] `flutter build apk`でreleaseビルドできる事を確認した
- [x] GooglePlayConsoleでリリース申請ができる事を確認した