### PR TITLE
#55 OSの時計が消えてしまうのでステータスバーを復活する

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,9 +8,6 @@ void main() async {
   // main()の中で非同期処理を行う際には、下記の実行が必須
   WidgetsFlutterBinding.ensureInitialized();
 
-  // Androidのナビゲーションバーのみ表示(ステータスバーは非表示)
-  SystemChrome.setEnabledSystemUIOverlays([SystemUiOverlay.bottom]);
-
   // iOS,Androidともに縦向き固定
   SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]).then(
     (_) {


### PR DESCRIPTION
## 関連のIssue
- #55（ ※ このプルリクがマージされたら、自動でクローズされます -> コマンド：close #55 ）

## 修正箇所の概要
- OSの時計が消えてしまうのでステータスバーを復活しました

## ビルド後の画面イメージ
| iOS | Android|
|-|-|
| <image src="https://user-images.githubusercontent.com/55462291/113463149-3eb84600-945f-11eb-9c76-7fb34cbc914d.png" width="250"> | <image src="https://user-images.githubusercontent.com/55462291/113504771-2a666d00-9575-11eb-8cd6-f77fec7148c0.png" width="250"> |

## 実装者が行ったテスト
- [x] iOSのステータスバーにOSの時計が表示されている事を確認しました
- [x] AndroidのステータスバーにOSの時計が表示されている事を確認しました